### PR TITLE
Fix parsing commands comments error when several on same move

### DIFF
--- a/fixtures/pgns/lichess_multiple_command.pgn
+++ b/fixtures/pgns/lichess_multiple_command.pgn
@@ -1,0 +1,24 @@
+[Event "Rated blitz game"]
+[Site "https://lichess.org/1CsNl5oG"]
+[Date "2023.03.13"]
+[White "Bongcloudisgood"]
+[Black "ChessMood"]
+[Result "1-0"]
+[GameId "1CsNl5oG"]
+[UTCDate "2023.03.13"]
+[UTCTime "06:44:06"]
+[WhiteElo "2737"]
+[BlackElo "2537"]
+[WhiteRatingDiff "+2"]
+[BlackRatingDiff "-4"]
+[BlackTitle "GM"]
+[Variant "Standard"]
+[TimeControl "180+0"]
+[ECO "E00"]
+[Opening "Catalan Opening"]
+[Termination "Normal"]
+[Annotator "lichess.org"]
+
+1. d4 { [%eval 0.0] [%clk 0:03:00] } 1... Nf6 { [%eval 0.28] [%clk 0:03:00] } 2. c4 { [%eval 0.16] [%clk 0:02:59] } 2... e6 { [%eval 0.23] [%clk 0:03:00] } 3. g3 { [%eval 0.14] [%clk 0:02:58] } { E00 Catalan Opening } 3... Bb4+ { [%eval 0.23] [%clk 0:02:59] } 4. Nd2 { [%eval 0.13] [%clk 0:02:58] } 4... O-O { [%eval 0.27] [%clk 0:02:59] } 5. Bg2 { [%eval 0.0] [%clk 0:02:57] } 5... d5 { [%eval 0.12] [%clk 0:02:57] } 6. Nf3 { [%eval 0.21] [%clk 0:02:57] } 6... c5 { [%eval 0.36] [%clk 0:02:56] } 7. a3 { [%eval 0.29] [%clk 0:02:55] } 7... Bxd2+ { [%eval 0.48] [%clk 0:02:55] } 8. Qxd2 { [%eval 0.27] [%clk 0:02:55] } 8... dxc4 { [%eval 0.54] [%clk 0:02:54] } 9. dxc5 { [%eval 0.43] [%clk 0:02:55] } 9... Na6 { [%eval 0.48] [%clk 0:02:53] } 10. c6 { [%eval 0.36] [%clk 0:02:50] } 10... Nd5?! { (0.36 → 1.40) Inaccuracy. Nc5 was best. } { [%eval 1.4] [%clk 0:02:48] } (10... Nc5) 11. Qc2 { [%eval 1.51] [%clk 0:02:28] } 11... h6 { [%eval 1.58] [%clk 0:02:44] } 12. Qxc4 { [%eval 1.3] [%clk 0:02:26] } 12... bxc6 { [%eval 1.47] [%clk 0:02:43] } 13. O-O { [%eval 1.18] [%clk 0:02:17] } 13... Rb8?! { (1.18 → 2.04) Inaccuracy. Bb7 was best. } { [%eval 2.04] [%clk 0:02:41] } (13... Bb7 14. Rd1 Qf6 15. Nd2 Rad8 16. Qc2 Nb6 17. Ne4 Qe7 18. Be3 c5 19. Rxd8 Rxd8 20. Rc1) 14. Rd1 { [%eval 1.79] [%clk 0:02:14] } 14... Bd7?? { (1.79 → 5.55) Blunder. Qe7 was best. } { [%eval 5.55] [%clk 0:02:40] } (14... Qe7 15. Qc2) 15. Ne5?! { (5.55 → 4.23) Inaccuracy. Qxa6 was best. } { [%eval 4.23] [%clk 0:02:11] } (15. Qxa6 Qf6 16. e4 c5 17. Qe2 Bb5 18. Qe1 Nb6 19. Bf4 Qxb2) 15... Qe7?! { (4.23 → 5.49) Inaccuracy. Bc8 was best. } { [%eval 5.49] [%clk 0:02:38] } (15... Bc8 16. e4 Qc7 17. exd5 Qxe5 18. Bf4 Qxb2 19. dxe6 fxe6 20. Bxb8 Nxb8 21. Rab1 Qe5 22. Qe4) 16. b4 { [%eval 4.58] [%clk 0:02:08] } 16... Rfc8 { [%eval 5.33] [%clk 0:02:36] } 17. Qxa6 { [%eval 4.75] [%clk 0:02:07] } 17... c5 { [%eval 5.3] [%clk 0:02:34] } 18. Nxd7 { [%eval 5.57] [%clk 0:02:05] } 18... Qxd7 { [%eval 5.63] [%clk 0:02:33] } 19. e4 { [%eval 5.09] [%clk 0:01:59] } 19... Nxb4 { [%eval 5.32] [%clk 0:02:30] } 20. Rxd7 { [%eval 4.96] [%clk 0:01:48] } 20... Nxa6 { [%eval 4.95] [%clk 0:02:29] } 21. Rxa7 { [%eval 4.91] [%clk 0:01:48] } 21... Nc7 { [%eval 5.55] [%clk 0:02:28] } 22. Be3 { [%eval 4.9] [%clk 0:01:45] } 22... Nb5 { [%eval 4.62] [%clk 0:02:27] } 23. Ra5 { [%eval 4.05] [%clk 0:01:42] } 23... Nd4 { [%eval 4.29] [%clk 0:02:26] } 24. Rd1 { [%eval 4.13] [%clk 0:01:30] } 24... Nb3 { [%eval 4.23] [%clk 0:02:24] } 25. Ra7 { [%eval 4.43] [%clk 0:01:25] } 25... c4 { [%eval 4.83] [%clk 0:02:23] } 26. Rdd7 { [%eval 4.81] [%clk 0:01:17] } 26... c3 { [%eval 5.67] [%clk 0:02:22] } 27. Rxf7 { [%eval 5.58] [%clk 0:01:16] } 27... c2 { [%eval 5.58] [%clk 0:02:20] } 28. Rxg7+ { [%eval 5.73] [%clk 0:01:15] } 28... Kh8 { [%eval 5.72] [%clk 0:02:18] } 29. Rh7+ { [%eval 5.81] [%clk 0:01:10] } 29... Kg8 { [%eval 5.65] [%clk 0:02:17] } 30. Bf1 { [%eval 5.24] [%clk 0:01:02] } 30... c1=Q { [%eval 5.23] [%clk 0:02:16] } 31. Bxc1 { [%eval 5.22] [%clk 0:00:59] } 31... Rxc1 { [%eval 5.17] [%clk 0:02:16] } 32. Kg2 { [%eval 5.32] [%clk 0:00:54] } 32... Nd2 { [%eval 5.46] [%clk 0:02:11] } 33. Bd3 { [%eval 5.24] [%clk 0:00:51] } 33... Rc3 { [%eval 6.0] [%clk 0:02:10] } 34. Rag7+ { [%eval 5.81] [%clk 0:00:48] } 34... Kf8 { [%eval 5.73] [%clk 0:02:08] } 35. Rf7+ { [%eval 5.89] [%clk 0:00:48] } 35... Kg8 { [%eval 5.5] [%clk 0:02:07] } 36. Rd7 { [%eval 5.62] [%clk 0:00:45] } 36... Kf8?? { (5.62 → Mate in 1) Checkmate is now unavoidable. Nb3 was best. } { [%eval #1] [%clk 0:02:07] } (36... Nb3 37. Rhg7+ Kh8 38. Be2 Nc5 39. Rh7+ Kg8 40. Rdg7+ Kf8 41. Rc7 Kg8 42. Bh5 Rxa3 43. Rcg7+) 37. Rh8# { [%clk 0:00:45] } { White wins by checkmate. } 1-0
+
+

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/corentings/chess/v2
 
 go 1.22.0
 
-require github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b
+require (
+	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b
+	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
+)

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c h1:KL/ZBHXgKGVmuZBZ01Lt57yE5ws8ZPSkkihmEyq7FXc=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/pgn.go
+++ b/pgn.go
@@ -16,6 +16,7 @@ package chess
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/exp/maps"
 	"strconv"
 )
 
@@ -194,8 +195,16 @@ func (p *Parser) parseMoveText() error {
 				return err
 			}
 			if p.currentMove != nil {
-				p.currentMove.comments = comment
-				p.currentMove.command = commandMap
+				if p.currentMove.command != nil {
+					maps.Copy(p.currentMove.command, commandMap)
+				} else {
+					p.currentMove.command = commandMap
+				}
+				if p.currentMove.comments != "" {
+					p.currentMove.comments += " " + comment
+				} else {
+					p.currentMove.comments = comment
+				}
 			}
 
 		case VariationStart:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new Lichess chess game PGN file with detailed game metadata
	- Enhanced PGN parsing to support multiple game commands and comments

- **Tests**
	- Added comprehensive test for parsing complex PGN files with multiple commands

- **Dependencies**
	- Added new Go library dependency `golang.org/x/exp`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->