### PR TITLE
improve: support multiple move notations via PushNotationMove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+testdata/fuzz/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/game.go
+++ b/game.go
@@ -735,6 +735,8 @@ type PushMoveOptions struct {
 	ForceMainline bool
 }
 
+// Deprecated: use PushNotationMove instead.
+//
 // PushMove adds a move in algebraic notation to the game.
 // Returns an error if the move is invalid.
 //

--- a/game.go
+++ b/game.go
@@ -763,6 +763,39 @@ func (g *Game) PushMove(algebraicMove string, options *PushMoveOptions) error {
 	return nil
 }
 
+// PushNotationMove adds a move to the game using any supported notation.
+// It returns an error if the move is invalid.
+//
+// Example:
+//
+//	err := game.PushNotationMove("e4", chess.AlgebraicNotation{}, &PushMoveOptions{ForceMainline: true})
+//	if err != nil {
+//	  panic(err)
+//	}
+//
+//	game.PushNotationMove("c7c5", chess.UCINotation{}, nil)
+//	game.PushNotationMove("Nc1f3", chess.LongAlgebraicNotation{}, nil)
+func (g *Game) PushNotationMove(moveStr string, notation Notation, options *PushMoveOptions) error {
+	if options == nil {
+		options = &PushMoveOptions{}
+	}
+
+	move, err := notation.Decode(g.pos, moveStr)
+	if err != nil {
+		return err
+	}
+
+	existingMove := g.findExistingMove(move)
+	g.addOrReorderMove(move, existingMove, options.ForceMainline)
+
+	g.updatePosition(move)
+	g.currentMove = move
+
+	g.evaluatePositionStatus()
+
+	return nil
+}
+
 func (g *Game) parseAndValidateMove(algebraicMove string) (*Move, error) {
 	tokens, err := TokenizeGame(&GameScanned{Raw: algebraicMove})
 	if err != nil {

--- a/game.go
+++ b/game.go
@@ -778,24 +778,12 @@ func (g *Game) PushMove(algebraicMove string, options *PushMoveOptions) error {
 //	game.PushNotationMove("c7c5", chess.UCINotation{}, nil)
 //	game.PushNotationMove("Nc1f3", chess.LongAlgebraicNotation{}, nil)
 func (g *Game) PushNotationMove(moveStr string, notation Notation, options *PushMoveOptions) error {
-	if options == nil {
-		options = &PushMoveOptions{}
-	}
-
 	move, err := notation.Decode(g.pos, moveStr)
 	if err != nil {
 		return err
 	}
 
-	existingMove := g.findExistingMove(move)
-	g.addOrReorderMove(move, existingMove, options.ForceMainline)
-
-	g.updatePosition(move)
-	g.currentMove = move
-
-	g.evaluatePositionStatus()
-
-	return nil
+	return g.Move(move, options)
 }
 
 // Move method adds a move to the game using a Move struct.

--- a/game.go
+++ b/game.go
@@ -798,6 +798,33 @@ func (g *Game) PushNotationMove(moveStr string, notation Notation, options *Push
 	return nil
 }
 
+// Move method adds a move to the game using a Move struct.
+// It returns an error if the move is invalid.
+//
+// Example:
+//
+//	possibleMove := game.ValidMoves()[0]
+//
+//	err := game.Move(&possibleMove, nil)
+//	if err != nil {
+//	    panic(err)
+//	}
+func (g *Game) Move(move *Move, options *PushMoveOptions) error {
+	if options == nil {
+		options = &PushMoveOptions{}
+	}
+
+	existingMove := g.findExistingMove(move)
+	g.addOrReorderMove(move, existingMove, options.ForceMainline)
+
+	g.updatePosition(move)
+	g.currentMove = move
+
+	g.evaluatePositionStatus()
+
+	return nil
+}
+
 func (g *Game) parseAndValidateMove(algebraicMove string) (*Move, error) {
 	tokens, err := TokenizeGame(&GameScanned{Raw: algebraicMove})
 	if err != nil {

--- a/game_test.go
+++ b/game_test.go
@@ -1174,3 +1174,25 @@ func TestGameString(t *testing.T) {
 		})
 	}
 }
+
+func FuzzTestPushNotationMove(f *testing.F) {
+	f.Add("e2e4", 0)
+	f.Add("e4", 1)
+	f.Add("Nb1c3", 2)
+
+	f.Fuzz(func(t *testing.T, move string, notationType int) {
+		game := NewGame()
+
+		var notation Notation
+		switch notationType % 3 {
+		case 0:
+			notation = UCINotation{}
+		case 1:
+			notation = AlgebraicNotation{}
+		case 2:
+			notation = LongAlgebraicNotation{}
+		}
+
+		_ = game.PushNotationMove(move, notation, nil)
+	})
+}


### PR DESCRIPTION
This PR makes major improvements to move input flexibility in the library by:

- Marking `PushMove` as deprecated
- Adding `PushNotationMove`, which accepts a move in string format, a notation implementation, and `PushMoveOptions`
- Adding `Move()` method, allowing moves to be pushed using a `Move` struct (instead of notation strings)

## How

- Introduced `PushNotationMove(moveStr string, notation Notation, opts *PushMoveOptions) error`
- Moved core logic into `Move(*Move, *PushMoveOptions)`, reused internally by `PushNotationMove`
- Preserved backward compatibility while encouraging the new API
- Added fuzz test


Related to issue #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced move submission now accepts multiple notation formats with improved error handling while ensuring backward compatibility.
- **Tests**
	- Added comprehensive tests to validate the robustness and reliability of the new move submission functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->