### PR TITLE
Fix: handle castle tags correctly

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -173,12 +173,25 @@ func standardMoves(pos *Position, first bool) []Move {
 //   - EnPassant: The move is an en passant capture
 //   - Check: The move puts the opponent in check
 //   - inCheck: The move leaves the moving side's king in check (illegal)
+//   - KingSideCastle: The move is a king-side castle
+//   - QueenSideCastle: The move is a queen-side castle
 func addTags(m *Move, pos *Position) {
 	p := pos.board.Piece(m.s1)
 	if pos.board.isOccupied(m.s2) {
 		m.AddTag(Capture)
 	} else if m.s2 == pos.enPassantSquare && p.Type() == Pawn {
 		m.AddTag(EnPassant)
+	}
+	// determine if move is castle
+	if (p == WhiteKing && m.s1 == E1) || (p == BlackKing && m.s1 == E8) {
+		switch m.s2 {
+		case C1, C8:
+			m.AddTag(QueenSideCastle)
+			break
+		case G1, G8:
+			m.AddTag(KingSideCastle)
+			break
+		}
 	}
 	// determine if in check after move (makes move invalid)
 	cp := pos.copy()

--- a/engine_test.go
+++ b/engine_test.go
@@ -94,6 +94,86 @@ func BenchmarkStandardMoves_BoardDensity(b *testing.B) {
 	}
 }
 
+func TestAddTags(t *testing.T) {
+	tests := []struct {
+		name string
+		move Move
+		want MoveTag
+		fen  string
+	}{
+		{
+			name: "move with queen side castle",
+			move: Move{s1: E8, s2: C8},
+			want: QueenSideCastle,
+			fen:  "r3kb1r/p2nqppp/5n2/1B2p1B1/4P3/1Q6/PPP2PPP/R3K2R b KQkq - 1 12",
+		},
+		{
+			name: "move with king side castle",
+			move: Move{s1: E1, s2: G1},
+			want: KingSideCastle | Check,
+			fen:  "r4b1r/ppp3pp/8/4p3/2Pq4/3P4/PP2QPPP/2k1K2R w K - 0 18",
+		},
+		{
+			name: "move with king side castle and check",
+			move: Move{s1: E1, s2: G1},
+			want: KingSideCastle | Check,
+			fen:  "r4b1r/ppp3pp/8/4p3/2Pq4/3P1Q2/PP3PPP/1k2K2R w K - 2 19",
+		},
+		{
+			name: "move with check",
+			move: Move{s1: D7, s2: A4},
+			want: Check,
+			fen:  "rn2k1r1/ppqb4/4p1n1/3pPp1Q/8/P1PP4/4NPPP/R1BK1B1R b q - 0 14",
+		},
+		{
+			name: "move leaves king in check",
+			move: Move{s1: G6, s2: F8},
+			want: inCheck,
+			fen:  "r3k1r1/ppq5/2n1p1n1/3p1pBQ/b2P3P/P1P5/4NPP1/R3KB1R b q - 0 18",
+		},
+		{
+			name: "capture move",
+			move: Move{s1: G2, s2: G3},
+			want: Capture,
+			fen:  "8/7p/3k2p1/8/2p2P2/R5bP/6K1/4r3 w - - 0 44",
+		},
+		{
+			name: "normal move without tags",
+			move: Move{s1: D6, s2: D5},
+			want: 0,
+			fen:  "8/7p/3k2p1/8/2p2P2/R5KP/8/4r3 b - - 0 44",
+		},
+		{
+			name: "en passant move",
+			move: Move{s1: E4, s2: F3},
+			want: EnPassant | Check,
+			fen:  "r3k2r/pbppqpb1/1pn3p1/7p/1N2pPn1/1PP4N/PB1P2PP/2QRKR2 b kq f3 0 1",
+		},
+		{
+			name: "normal move without tags",
+			move: Move{s1: B7, s2: A6},
+			want: 0,
+			fen:  "r3k2r/pbppqpb1/1pn3p1/7p/1N2pPn1/1PP4N/PB1P2PP/2QRKR2 b kq f3 0 1",
+		},
+		{
+			name: "en passant move with check",
+			move: Move{s1: E4, s2: F3},
+			want: EnPassant | Check,
+			fen:  "r3k1r1/pbppqpb1/1pn3p1/7p/1N2pPn1/1PP4N/PB1P2PP/2QRK1R1 b q f3 0 2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			addTags(&test.move, mustPosition(test.fen))
+
+			if test.move.tags != test.want {
+				t.Errorf("fen: %s | move: %s\ntags(%d) == expected_tags(%d)", test.fen, test.move.String(), test.move.tags, test.want)
+			}
+		})
+	}
+}
+
 // Helper function to convert FEN to Position
 func mustPosition(fen string) *Position {
 	fenObject, err := FEN(fen)

--- a/notation.go
+++ b/notation.go
@@ -162,7 +162,6 @@ func (UCINotation) Decode(pos *Position, s string) (*Move, error) {
 		return &m, nil
 	}
 
-	// check for check
 	addTags(&m, pos)
 
 	m.position = pos.Update(&m)

--- a/notation_test.go
+++ b/notation_test.go
@@ -145,6 +145,22 @@ func TestUCINotationDecode(t *testing.T) {
 			expectedPos: unsafeFEN("rnbQkb1r/ppp2ppp/5n2/4p3/4P3/2N5/PPP2PPP/R1B1KBNR b KQkq - 0 5"),
 		},
 		{
+			name:        "valid move with castle with check",
+			pos:         unsafeFEN("r4b1r/ppp3pp/8/4p3/2Pq4/3P1Q2/PP3PPP/1k2K2R w K - 2 19"),
+			input:       "e1g1",
+			want:        &Move{s1: E1, s2: G1, tags: Check | KingSideCastle},
+			wantErr:     false,
+			expectedPos: unsafeFEN("r4b1r/ppp3pp/8/4p3/2Pq4/3P1Q2/PP3PPP/1k3RK1 b - - 3 19"),
+		},
+		{
+			name:        "valid en passant move with check",
+			pos:         unsafeFEN("r3k1r1/pbppqpb1/1pn3p1/7p/1N2pPn1/1PP4N/PB1P2PP/2QRK1R1 b q f3 0 2"),
+			input:       "e4f3",
+			want:        &Move{s1: E4, s2: F3, tags: Check | EnPassant},
+			wantErr:     false,
+			expectedPos: unsafeFEN("r3k1r1/pbppqpb1/1pn3p1/7p/1N4n1/1PP2p1N/PB1P2PP/2QRK1R1 w q - 0 3"),
+		},
+		{
 			name:    "invalid UCI notation length",
 			pos:     nil,
 			input:   "e2e",


### PR DESCRIPTION
This PR fixes the UCINotation.Decode method by detect castle moves and tagging it correctly. In addition it adds unit tests to addTags function and uci Decode method.

Related to issue #34.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Moves involving castling are now automatically tagged as king-side or queen-side castling.
- **Bug Fixes**
  - Improved tagging for moves that combine special move types (castling, en passant) with check conditions.
- **Tests**
  - Added comprehensive tests for move tagging, including scenarios for castling, en passant, checks, and their combinations.
- **Style**
  - Removed an obsolete comment for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->