### PR TITLE
Add support for eval command

### DIFF
--- a/uci/cmd.go
+++ b/uci/cmd.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -116,6 +117,29 @@ var (
 	// CmdQuit (shouldn't be used directly as its handled by Engine.Close()) corresponds to the "quit" command:
 	// quit the program as soon as possible.
 	CmdQuit = cmdNoOptions{Name: "quit", F: func(_ *Engine) error {
+		return nil
+	}}
+
+	// CmdEval is a non-standard command that requests the engine's static evaluation of the current position.
+	CmdEval = cmdNoOptions{Name: "eval", F: func(e *Engine) error {
+		scanner := bufio.NewScanner(e.out)
+		for scanner.Scan() {
+			text := e.readLine(scanner)
+			if strings.Contains(text, "error") {
+				return errors.New("eval command not supported")
+			}
+			if strings.HasPrefix(text, "Final evaluation") {
+				parts := strings.Fields(text)
+				if len(parts) >= 3 {
+					evalStr := parts[2]
+					eval, err := strconv.ParseFloat(evalStr, 64)
+					if err == nil {
+						e.eval = int(math.Round(eval * 100))
+					}
+					break
+				}
+			}
+		}
 		return nil
 	}}
 )

--- a/uci/engine.go
+++ b/uci/engine.go
@@ -22,6 +22,7 @@ type Engine struct {
 	mu       *sync.RWMutex
 	position *CmdPosition
 	results  SearchResults
+	eval     int
 	debug    bool
 }
 
@@ -122,6 +123,12 @@ func (e *Engine) SearchResults() SearchResults {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	return e.results
+}
+
+func (e *Engine) Eval() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.eval
 }
 
 // Run runs the set of Cmds in the order given and returns an error if


### PR DESCRIPTION
Resolves #38 

Let me know if you want any changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an "eval" command to request evaluation scores from supported chess engines.
  - Introduced a method to retrieve the most recent evaluation score for a given engine.

- **Tests**
  - Added tests to verify evaluation command behavior and score retrieval for different engines, including error handling for unsupported engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->