### PR TITLE
Fix ambiguous moves in PGN; Add PGN test case

### DIFF
--- a/game.go
+++ b/game.go
@@ -447,7 +447,7 @@ func writeMoves(node *Move, moveNum int, isWhite bool, sb *strings.Builder, subV
 	writeMoveNumber(moveNum, isWhite, subVariation, sb)
 
 	// Encode the move using your AlgebraicNotation.
-	writeMoveEncoding(node, currentMove, sb)
+	writeMoveEncoding(node, currentMove, subVariation, sb)
 
 	// Append a comment if present.
 	writeComments(currentMove, sb)
@@ -491,8 +491,13 @@ func writeMoveNumber(moveNum int, isWhite bool, subVariation bool, sb *strings.B
 	}
 }
 
-func writeMoveEncoding(node *Move, currentMove *Move, sb *strings.Builder) {
-	sb.WriteString(AlgebraicNotation{}.Encode(node.Position(), currentMove))
+func writeMoveEncoding(node *Move, currentMove *Move, subVariation bool, sb *strings.Builder) {
+	if subVariation && node.Parent() != nil {
+		moveStr := AlgebraicNotation{}.Encode(node.Parent().Position(), currentMove)
+		sb.WriteString(moveStr)
+	} else {
+		sb.WriteString(AlgebraicNotation{}.Encode(node.Position(), currentMove))
+	}
 }
 
 func writeComments(move *Move, sb *strings.Builder) {

--- a/game.go
+++ b/game.go
@@ -492,12 +492,7 @@ func writeMoveNumber(moveNum int, isWhite bool, subVariation bool, sb *strings.B
 }
 
 func writeMoveEncoding(node *Move, currentMove *Move, sb *strings.Builder) {
-	if node.Parent() == nil {
-		sb.WriteString(AlgebraicNotation{}.Encode(node.Position(), currentMove))
-	} else {
-		moveStr := AlgebraicNotation{}.Encode(node.Parent().Position(), currentMove)
-		sb.WriteString(moveStr)
-	}
+	sb.WriteString(AlgebraicNotation{}.Encode(node.Position(), currentMove))
 }
 
 func writeComments(move *Move, sb *strings.Builder) {

--- a/game_test.go
+++ b/game_test.go
@@ -1046,6 +1046,23 @@ func TestGameString(t *testing.T) {
 			expected: "1. e4 e5 2. Nf3 *",
 		},
 		{
+			name: "GameStringWithLongerGame",
+			setup: func() *Game {
+				g := NewGame()
+				_ = g.PushMove("Nf3", nil)
+				_ = g.PushMove("Nc6", nil)
+				_ = g.PushMove("Nc3", nil)
+				_ = g.PushMove("e6", nil)
+				_ = g.PushMove("e4", nil)
+				_ = g.PushMove("a6", nil)
+				_ = g.PushMove("Ne2", nil)
+				_ = g.PushMove("Nf6", nil)
+				_ = g.PushMove("Ned4", nil)
+				return g
+			},
+			expected: "1. Nf3 Nc6 2. Nc3 e6 3. e4 a6 4. Ne2 Nf6 5. Ned4 *",
+		},
+		{
 			name: "GameStringWithComments",
 			setup: func() *Game {
 				g := NewGame()


### PR DESCRIPTION
Ambiguous moves were being generated in game PGNs as per #44. The reason was that the generator was looking at the predecessor position when determining what information was needed for the current move. This PR fixes the issue. 

EDIT: The predecessor position was necessary for processing subvariations in the PGN encode. This was brough back in a more robust way, so that ambiguous moves were fixed while keeping the predecessor position for the subvariations. Also added a test case that captures the example from #44 