### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: setup
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -54,6 +56,8 @@ jobs:
   vulncheck:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -71,6 +75,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test  # Ensure changelog runs only if tests pass
     if: github.event_name == 'pull_request'  # Run only for pull requests
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -83,6 +90,8 @@ jobs:
   report-card:
     runs-on: ubuntu-latest
     needs: test  # Ensure report card runs only if tests pass
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/CorentinGS/chess/security/code-scanning/5](https://github.com/CorentinGS/chess/security/code-scanning/5)

To address this issue, a `permissions` block should be added to the workflow file. It can either be defined at the root level (applying to all jobs) or at the individual job level (customized for each job). Since the workflow contains multiple jobs, using job-specific `permissions` blocks provides greater control and flexibility.

The following permissions are recommended:
- For jobs that only need to read repository contents (e.g., `test`, `vulncheck`, `report-card`), set `contents: read`.
- For jobs requiring write access (e.g., `changelog`), set only the required type of write permissions, such as `pull-requests: write`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
