### PR TITLE
Add uci.Engine.Getpid()

### DIFF
--- a/uci/engine.go
+++ b/uci/engine.go
@@ -57,10 +57,17 @@ func New(path string, opts ...func(e *Engine)) (*Engine, error) {
 	for _, opt := range opts {
 		opt(e)
 	}
-	go func() {
-		_ = e.cmd.Run()
-	}()
+	err = e.cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("uci: failed to start executable %s: %w", path, err)
+	}
+	go e.cmd.Wait()
+
 	return e, nil
+}
+
+func (e *Engine) Getpid() int {
+	return e.cmd.Process.Pid
 }
 
 // ID returns the id values returned from the most recent CmdUCI invocation.  It includes


### PR DESCRIPTION
This change adds a Getpid() method receiver to uci.Engine. This enables callers to interact with the engine process directly. For example callers may renice the process to allow the engine to run at a lower priority. In practice this is helpful in improving system responsiveness when running the engine with high thread counts and/or larger hash sizes.

(cherry picked from commit 3899b2d7783f6f40d3681dfbf152048d0dc05fa1)