### PR TITLE
bugfix: game.Clone() is not a deep copy

### DIFF
--- a/game.go
+++ b/game.go
@@ -685,19 +685,13 @@ func (g *Game) copy(game *Game) {
 
 // Clone returns a deep copy of the game.
 func (g *Game) Clone() *Game {
-	return &Game{
-		tagPairs:             g.tagPairs,
-		rootMove:             g.rootMove,
-		currentMove:          g.currentMove,
-		pos:                  g.pos,
-		outcome:              g.outcome,
-		method:               g.method,
-		comments:             g.Comments(),
-		ignoreAutomaticDraws: g.ignoreAutomaticDraws,
-	}
+	ret := &Game{}
+	ret.copy(g)
+
+	return ret
 }
 
-// Positions returns all positions in the game.
+// Positions returns all positions in the game in the main line.
 // This includes the starting position and all positions after each move.
 func (g *Game) Positions() []*Position {
 	positions := make([]*Position, 0)

--- a/game_test.go
+++ b/game_test.go
@@ -834,6 +834,13 @@ func TestCloneGameStateWithTagPairs(t *testing.T) {
 	if clone.GetTagPair("Event") != "Test Event" {
 		t.Fatalf("expected tag pair 'Test Event' but got %s", clone.GetTagPair("Event"))
 	}
+
+	// modify original to ensure the clone is a true deep copy
+	original.AddTagPair("Event", "Test Event Modified")
+
+	if clone.GetTagPair("Event") != "Test Event" {
+		t.Fatalf("expected tag pair 'Test Event' but got %s", clone.GetTagPair("Event"))
+	}
 }
 
 func TestResignWhenGameInProgress(t *testing.T) {


### PR DESCRIPTION
Idiomatically, and per game.Clone()'s description, the returned *Game should be a deep copy. Existing code performs only a shallow copy of the tags slice.