### PR TITLE
bugfix: Fix Game.String() variations output

### DIFF
--- a/game_test.go
+++ b/game_test.go
@@ -1151,7 +1151,7 @@ func TestGameString(t *testing.T) {
 				g.GoBack()
 				return g
 			},
-			expected: "1. e4 e5 2. Nf3 (2. Nc3) (2. d4 d5 3. c4 (3. c3) ) *",
+			expected: "1. e4 e5 2. Nf3 (2. Nc3) (2. d4 d5 3. c4 (3. c3)) *",
 		},
 		{
 			name: "GameStringWithVariationsForBlack",
@@ -1186,7 +1186,7 @@ func TestGameString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := tt.setup()
 			if g.String() != tt.expected {
-				t.Fatalf("expected %v but got %v", tt.expected, g.String())
+				t.Fatalf("\n\tExpected:'%v'\n\tGot:     '%v'\n", tt.expected, g.String())
 			}
 		})
 	}

--- a/pgn.go
+++ b/pgn.go
@@ -100,6 +100,9 @@ func (p *Parser) Parse() (*Game, error) {
 		return nil, err
 	}
 
+	if p.game.outcome == UnknownOutcome {
+		p.game.outcome = NoOutcome
+	}
 	return p.game, nil
 }
 

--- a/pgn_test.go
+++ b/pgn_test.go
@@ -142,6 +142,17 @@ func TestGameWithVariations(t *testing.T) {
 		t.Fatalf("game moves are not correct, expected 7, got %d", len(game.Moves()))
 	}
 
+	lines := strings.Split(game.String(), "\n")
+	if len(lines) == 0 {
+		t.Fatalf("game output blank")
+	}
+
+	const expectedLastLine = "1. e4 (1. e3 e5) 1... e5 (1... d6 2. d4 Nf6 3. Nc3 e5 4. dxe5 (4. Nf3 Nbd7) 4... dxe5 5. Qxd8+ Kxd8) 2. Nf3 (2. Nc3 Nf6 3. f4) 2... Nc6 3. d4 exd4 4. Nxd4 *"
+	lastLine := lines[len(lines)-1]
+	if lastLine != expectedLastLine {
+		t.Fatalf("game output not correct\n\tExpected:'%v'\n\tGot:     '%v'\n",
+			expectedLastLine, lastLine)
+	}
 }
 
 func TestSingleGameFromPGN(t *testing.T) {


### PR DESCRIPTION
After a variation has been output, the move number should always be repeated.