### PR TITLE
Add Scanner option to expand variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,8 +389,35 @@ if err != nil {
 defer f.Close()
 
 scanner := chess.NewScanner(f)
-for scanner.Scan() {
-	game := scanner.Next()
+// Read all games
+for scanner.HasNext() {
+	game, err := scanner.ParseNext()
+	if err != nil {
+		log.Fatal("Failed to parse game: %v", err)
+	}
+	fmt.Println(game.GetTagPair("Site"))
+	// Output &{Site https://lichess.org/8jb5kiqw}
+}
+```
+
+#### Scan PGN expanding all variations
+
+To expand every variation into a distinct Game:
+
+```go
+f, err := os.Open("lichess_db_standard_rated_2013-01.pgn")
+if err != nil {
+	panic(err)
+}
+defer f.Close()
+
+scanner := chess.NewScanner(f, chess.WithExpandVariations())
+// Read all games
+for scanner.HasNext() {
+	game, err := scanner.ParseNext()
+	if err != nil {
+		log.Fatal("Failed to parse game: %v", err)
+	}
 	fmt.Println(game.GetTagPair("Site"))
 	// Output &{Site https://lichess.org/8jb5kiqw}
 }

--- a/game_test.go
+++ b/game_test.go
@@ -1217,19 +1217,11 @@ func FuzzTestPushNotationMove(f *testing.F) {
 func validateSplit(t *testing.T, origPgn string, expectedLastLines []string) {
 	reader := strings.NewReader(origPgn)
 	scanner := NewScanner(reader)
-	scannedGame, err := scanner.ScanGame()
+	game, err := scanner.ParseNext()
 	if err != nil {
-		t.Fatalf("fail to scan game: %s", err.Error())
+		t.Fatalf("fail to parse game: %s", err.Error())
 	}
-	tokens, err := TokenizeGame(scannedGame)
-	if err != nil {
-		t.Fatalf("fail to tokenize game: %s", err.Error())
-	}
-	parser := NewParser(tokens)
-	game, err := parser.Parse()
-	if err != nil {
-		t.Fatalf("fail to read games: %s", err.Error())
-	}
+
 	if game == nil {
 		t.Fatalf("game is nil")
 	}

--- a/move.go
+++ b/move.go
@@ -147,3 +147,30 @@ func (m *Move) Ply() int {
 	// After the move, it's Black's turn, so the move was by White
 	return (moveNumber)*2 + 0
 }
+
+// Clone returns a deep copy of a move.
+//
+// Per-field exceptions:
+//
+//	parent: not copied; the clone'd move has no parent
+//	children: not copied; the clone'd move has no children
+func (m *Move) Clone() *Move {
+	ret := &Move{}
+	ret.parent = nil
+	ret.position = m.position.copy()
+	ret.nag = m.nag
+	ret.comments = m.comments
+	ret.children = make([]*Move, 0)
+	ret.number = m.number
+	ret.tags = m.tags
+	ret.s1 = m.s1
+	ret.s2 = m.s2
+	ret.promo = m.promo
+
+	ret.command = make(map[string]string)
+	for k, v := range m.command {
+		ret.command[k] = v
+	}
+
+	return ret
+}

--- a/move_test.go
+++ b/move_test.go
@@ -439,3 +439,68 @@ func moveIsValid(pos *Position, m *Move, useTags bool) bool {
 	}
 	return false
 }
+
+func assertMovesAreEqual(t *testing.T, m1, m2 *Move) {
+	if m1.parent != m2.parent {
+		t.Fatalf("cloned mv %s parent is not the same", m1)
+	}
+	if m1.position.String() != m2.position.String() {
+		t.Fatalf("cloned mv %s position is not the same", m1)
+	}
+	if m1.nag != m2.nag {
+		t.Fatalf("cloned mv %s nag is not the same", m1)
+	}
+	if m1.comments != m2.comments {
+		t.Fatalf("cloned mv %s comments is not the same", m1)
+	}
+	if m1.number != m2.number {
+		t.Fatalf("cloned mv %s number is not the same", m1)
+	}
+	if m1.tags != m2.tags {
+		t.Fatalf("cloned mv %s tags is not the same", m1)
+	}
+	if m1.s1 != m2.s1 {
+		t.Fatalf("cloned mv %s s1 is not the same", m1)
+	}
+	if m1.s2 != m2.s2 {
+		t.Fatalf("cloned mv %s s2 is not the same", m1)
+	}
+	if m1.promo != m2.promo {
+		t.Fatalf("cloned mv %s s2 is not the same", m1)
+	}
+
+	if len(m1.command) != len(m2.command) {
+		t.Fatalf("cloned mv %s len(command) is not the same", m1)
+	} else {
+		for k, v1 := range m1.command {
+			v2, ok := m2.command[k]
+			if !ok || v2 != v1 {
+				t.Fatalf("cloned mv %s command[%v] is not the same", m1, k)
+			}
+		}
+	}
+	if len(m1.children) != len(m2.children) {
+		t.Fatalf("cloned mv %s len(command) is not the same", m1)
+	} else {
+		for idx, c1 := range m1.children {
+			c2 := m2.children[idx]
+			assertMovesAreEqual(t, c1, c2)
+		}
+	}
+}
+
+func TestMoveClone(t *testing.T) {
+	for _, mt := range validMoves {
+		mt.m.position = mt.pos
+		clonedM1 := mt.m.Clone()
+		assertMovesAreEqual(t, mt.m, clonedM1)
+		clonedM1.SetCommand("foo", "bar")
+		clonedM2 := clonedM1.Clone()
+		assertMovesAreEqual(t, clonedM1, clonedM2)
+		clonedM1.SetCommand("foo", "bar modified")
+		fooVal, ok := clonedM2.GetCommand("foo")
+		if !ok || fooVal != "bar" {
+			t.Fatalf("cloned mv %s is not a deep copy", clonedM2)
+		}
+	}
+}

--- a/pgn_test.go
+++ b/pgn_test.go
@@ -91,22 +91,10 @@ func TestGamesFromPGN(t *testing.T) {
 	for idx, test := range validPGNs {
 		reader := strings.NewReader(test.PGN)
 		scanner := NewScanner(reader)
-		scannedGame, err := scanner.ScanGame()
+		game, err := scanner.ParseNext()
 		if err != nil {
-			t.Fatalf("fail to scan game from valid pgn %d: %s", idx, err.Error())
+			t.Fatalf("fail to parse game from valid pgn %d: %s", idx, err.Error())
 		}
-
-		tokens, err := TokenizeGame(scannedGame)
-		if err != nil {
-			t.Fatalf("fail to tokenize game from valid pgn %d: %s", idx, err.Error())
-		}
-
-		parser := NewParser(tokens)
-		game, err := parser.Parse()
-		if err != nil {
-			t.Fatalf("fail to read games from valid pgn %d: %s", idx, err.Error())
-		}
-
 		if game == nil {
 			t.Fatalf("game is nil")
 		}
@@ -118,22 +106,10 @@ func TestGameWithVariations(t *testing.T) {
 	reader := strings.NewReader(pgn)
 
 	scanner := NewScanner(reader)
-	scannedGame, err := scanner.ScanGame()
+	game, err := scanner.ParseNext()
 	if err != nil {
-		t.Fatalf("fail to scan game from valid pgn: %s", err.Error())
+		t.Fatalf("fail to parse game from pgn: %s", err.Error())
 	}
-
-	tokens, err := TokenizeGame(scannedGame)
-	if err != nil {
-		t.Fatalf("fail to tokenize game from valid pgn: %s", err.Error())
-	}
-
-	parser := NewParser(tokens)
-	game, err := parser.Parse()
-	if err != nil {
-		t.Fatalf("fail to read games from valid pgn: %s", err.Error())
-	}
-
 	if game == nil {
 		t.Fatalf("game is nil")
 	}
@@ -150,18 +126,7 @@ func TestSingleGameFromPGN(t *testing.T) {
 
 	scanner := NewScanner(reader)
 
-	scannedGame, err := scanner.ScanGame()
-	if err != nil {
-		t.Fatalf("fail to scan game from valid pgn: %s", err.Error())
-	}
-
-	tokens, err := TokenizeGame(scannedGame)
-	if err != nil {
-		t.Fatalf("fail to tokenize game from valid pgn: %s", err.Error())
-	}
-
-	parser := NewParser(tokens)
-	game, err := parser.Parse()
+	game, err := scanner.ParseNext()
 	if err != nil {
 		t.Fatalf("fail to read games from valid pgn: %s", err.Error())
 	}
@@ -320,18 +285,7 @@ func TestCompleteGame(t *testing.T) {
 	reader := strings.NewReader(pgn)
 
 	scanner := NewScanner(reader)
-	scannedGame, err := scanner.ScanGame()
-	if err != nil {
-		t.Fatalf("fail to scan game from valid pgn: %s", err.Error())
-	}
-
-	tokens, err := TokenizeGame(scannedGame)
-	if err != nil {
-		t.Fatalf("fail to tokenize game from valid pgn: %s", err.Error())
-	}
-
-	parser := NewParser(tokens)
-	game, err := parser.Parse()
+	game, err := scanner.ParseNext()
 	if err != nil {
 		t.Fatalf("fail to read games from valid pgn: %s", err.Error())
 	}
@@ -402,18 +356,7 @@ func TestLichessMultipleCommand(t *testing.T) {
 	scanner := NewScanner(file)
 
 	// Test first game
-	scannedGame, err := scanner.ScanGame()
-	if err != nil {
-		t.Fatalf("Failed to read first game: %v", err)
-	}
-
-	tokens, err := TokenizeGame(scannedGame)
-	if err != nil {
-		t.Fatalf("Failed to tokenize first game: %v", err)
-	}
-
-	parser := NewParser(tokens)
-	game, err := parser.Parse()
+	game, err := scanner.ParseNext()
 	if err != nil {
 		t.Fatalf("fail to read games from valid pgn: %s", err.Error())
 	}
@@ -464,18 +407,7 @@ func TestParseMoveWithNAGAndComment(t *testing.T) {
 1. e4 $1 {Good move} e5 {Solid} $2 2. Nf3 $3 {Another comment} Nc6 $4 {Yet another}`
 
 	scanner := NewScanner(strings.NewReader(pgn))
-	scannedGame, err := scanner.ScanGame()
-	if err != nil {
-		t.Fatalf("fail to scan game: %v", err)
-	}
-
-	tokens, err := TokenizeGame(scannedGame)
-	if err != nil {
-		t.Fatalf("fail to tokenize game: %v", err)
-	}
-
-	parser := NewParser(tokens)
-	game, err := parser.Parse()
+	game, err := scanner.ParseNext()
 	if err != nil {
 		t.Fatalf("fail to parse game: %v", err)
 	}
@@ -511,18 +443,7 @@ func TestVariationMoveNumbers(t *testing.T) {
 1. e4 e5 2. Nf3 Nc6 3. Bb5 (3. Bc4 Nf6 4. d3) a6 4. Ba4 Nf6 5. O-O Be7 1-0`
 
 	scanner := NewScanner(strings.NewReader(pgn))
-	scannedGame, err := scanner.ScanGame()
-	if err != nil {
-		t.Fatalf("fail to scan game: %v", err)
-	}
-
-	tokens, err := TokenizeGame(scannedGame)
-	if err != nil {
-		t.Fatalf("fail to tokenize game: %v", err)
-	}
-
-	parser := NewParser(tokens)
-	game, err := parser.Parse()
+	game, err := scanner.ParseNext()
 	if err != nil {
 		t.Fatalf("fail to parse game: %v", err)
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -13,7 +13,7 @@ Example usage:
 	for scanner.HasNext() {
 		game, err := scanner.ParseNext()
 		if err != nil {
-			log.Fatal("Failed to parse game: %v", err)
+			log.Fatalf("Failed to parse game: %v", err)
 		}
 		// Process game
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -11,15 +11,12 @@ Example usage:
 
 	// Read all games
 	for scanner.HasNext() {
-		game, err := scanner.ScanGame()
+		game, err := scanner.ParseNext()
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal("Failed to parse game: %v", err)
 		}
 		// Process game
 	}
-
-	// Tokenize a specific game
-	tokens, err := TokenizeGame(game)
 */
 
 package chess
@@ -125,8 +122,8 @@ func (s *Scanner) ScanGame() (*GameScanned, error) {
 // Example:
 //
 //	for scanner.HasNext() {
-//	    game, err := scanner.ScanGame()
-//	    // Process game
+//	    scangame, err := scanner.ScanGame()
+//	    // Process scangame
 //	}
 func (s *Scanner) HasNext() bool {
 	// If we already have a buffered game, return true
@@ -144,6 +141,29 @@ func (s *Scanner) HasNext() bool {
 	// Store any error that occurred
 	s.lastError = s.scanner.Err()
 	return false
+}
+
+// ParseNext is a convenience wrapper combining the functionality of
+// ScanGame(), TokenizeGame(), NewParser(), and Parse() enabling
+// callers to simplify iterating over each Game within a pgn file.
+//
+// Example:
+//
+//	for scanner.HasNext() {
+//	    game, err := scanner.ParseNext()
+//	    // Process game
+//	}
+func (s *Scanner) ParseNext() (*Game, error) {
+	scannedGame, err := s.ScanGame()
+	if err != nil {
+		return nil, err
+	}
+	tokens, err := TokenizeGame(scannedGame)
+	if err != nil {
+		return nil, err
+	}
+	parser := NewParser(tokens)
+	return parser.Parse()
 }
 
 // Split function for bufio.Scanner to split PGN games.


### PR DESCRIPTION
These commits in aggregate add a feature to the Scanner to expand variations into individual Game instances during parsing. Together they address https://github.com/CorentinGS/chess/issues/52. Please note that tests will not pass until https://github.com/CorentinGS/chess/pull/55#issuecomment-3064307027 is merged as the new tests added here depend on that bugfix. I intentionally didn't re-include it with this PR to avoid confusion.