### PR TITLE
Bug fixes for working with .PGNs that contain FEN position tags.

### DIFF
--- a/fixtures/pgns/multi_frompos_games.pgn
+++ b/fixtures/pgns/multi_frompos_games.pgn
@@ -1,0 +1,66 @@
+[Event "Slav Defense"]
+[Site ""]
+[Date "2025.07.12"]
+[Round "1"]
+[White ""]
+[Black ""]
+[Result "*"]
+[UTCDate "2025.07.12"]
+[UTCTime "15:51:00"]
+[Variant "Standard"]
+[ECO "D10"]
+
+1. d4 d5 2. c4 c6 { [%eval 0.21] } *
+
+
+[Event "Slav Defense: Three Knights Variation"]
+[Site ""]
+[Date "2025.07.12"]
+[Round "1"]
+[White ""]
+[Black ""]
+[Result "*"]
+[UTCDate "2025.07.12"]
+[UTCTime "15:51:00"]
+[Variant "Standard"]
+[ECO "D15"]
+[FEN "rnbqkbnr/pp2pppp/2p5/3p4/2PP4/8/PP2PPPP/RNBQKBNR w KQkq - 0 3"]
+[SetUp "1"]
+
+3. Nf3 (3. Nc3 Nf6 4. Nf3) 3... Nf6 4. Nc3 { [%eval 0.16] } *
+
+
+[Event "Slav Defense: Chebanenko Variation"]
+[Site ""]
+[Date "2025.07.12"]
+[Round "1"]
+[White ""]
+[Black ""]
+[Result "*"]
+[UTCDate "2025.07.12"]
+[UTCTime "15:51:01"]
+[Variant "Standard"]
+[ECO "D15"]
+[FEN "rnbqkb1r/pp2pppp/2p2n2/3p4/2PP4/2N2N2/PP2PPPP/R1BQKB1R b KQkq - 3 4"]
+[SetUp "1"]
+
+4... a6 { [%eval 0.19] } *
+
+
+[Event "Slav Defense: Chebanenko Variation, 5. cxd5"]
+[Site ""]
+[Date "2025.07.12"]
+[Round "1"]
+[White ""]
+[Black ""]
+[Result "*"]
+[UTCDate "2025.07.12"]
+[UTCTime "15:51:01"]
+[Variant "Standard"]
+[ECO "D15"]
+[FEN "rnbqkb1r/1p2pppp/p1p2n2/3p4/2PP4/2N2N2/PP2PPPP/R1BQKB1R w KQkq - 0 5"]
+[SetUp "1"]
+
+5. cxd5 (5. e3 e6 6. cxd5 cxd5) 5... cxd5 6. e3 e6 { [%eval 0.11] } *
+
+

--- a/fixtures/pgns/single_frompos.pgn
+++ b/fixtures/pgns/single_frompos.pgn
@@ -1,0 +1,17 @@
+[Event "Slav Defense: Chebanenko Variation, 5. cxd5"]
+[Site ""]
+[Date "2025.07.12"]
+[Round "1"]
+[White ""]
+[Black ""]
+[Result "*"]
+[UTCDate "2025.07.12"]
+[UTCTime "15:51:01"]
+[Variant "Standard"]
+[ECO "D15"]
+[FEN "rnbqkb1r/1p2pppp/p1p2n2/3p4/2PP4/2N2N2/PP2PPPP/R1BQKB1R w KQkq - 0 5"]
+[SetUp "1"]
+
+5. cxd5 (5. e3 e6 6. cxd5 cxd5) 5... cxd5 6. e3 e6 { [%eval 0.11] } *
+
+

--- a/lexer.go
+++ b/lexer.go
@@ -43,7 +43,7 @@ const (
 	CommentStart    // {
 	CommentEnd      // }
 	COMMENT         // The comment text
-	RESULT          // 1-0, 0-1, 1/2-1/2
+	RESULT          // 1-0, 0-1, 1/2-1/2, *
 	CAPTURE         // 'x' in moves
 	FILE            // a-h in moves when used as disambiguation
 	RANK            // 1-8 in moves when used as disambiguation
@@ -533,6 +533,8 @@ func (l *Lexer) NextToken() Token {
 	case 'x':
 		l.readChar()
 		return Token{Type: CAPTURE, Value: "x"}
+	case '*':
+		fallthrough
 	case '-':
 		return l.readResult()
 	case '$', '!', '?':

--- a/move.go
+++ b/move.go
@@ -120,8 +120,12 @@ func (m *Move) Children() []*Move {
 }
 
 func (m *Move) Number() int {
-	//return m.MoveNumber()
-	return int(m.number)
+	ret := int(m.number)
+	if ret == 0 { // 0 indicates the 'dummy' rootMove
+		ret = 1
+	}
+
+	return ret
 
 }
 

--- a/pgn.go
+++ b/pgn.go
@@ -602,10 +602,10 @@ func (p *Parser) parseVariation(parentMoveNumber uint64, parentPly int) error {
 				p.game.pos = newPos
 			}
 		} else {
-			p.game.pos = StartingPosition()
+			p.game.pos = p.game.rootMove.position.copy()
 		}
 	} else {
-		p.game.pos = StartingPosition()
+		p.game.pos = p.game.rootMove.position.copy()
 	}
 
 	p.currentMove = variationParent

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -237,7 +237,7 @@ func validateExpand(t *testing.T, scanner *Scanner, expectedLastLines []string) 
 	for scanner.HasNext() {
 		game, err := scanner.ParseNext()
 		if err != nil {
-			t.Fatalf("fail to parse game: %s", err.Error())
+			t.Fatalf("fail to parse game %v: %s", count+1, err.Error())
 		}
 
 		if game == nil {
@@ -287,6 +287,20 @@ func TestScannerNoExpand(t *testing.T) {
 	}
 
 	pgn := mustParsePGN("fixtures/pgns/variations.pgn")
+	reader := strings.NewReader(pgn)
+	scanner := NewScanner(reader)
+	validateExpand(t, scanner, expectedLastLines)
+}
+
+func TestScannerMultiFromPosNoExpand(t *testing.T) {
+	expectedLastLines := []string{
+		"1. d4 d5 2. c4 c6 { [%eval 0.21] } *",
+		"3. Nf3 (3. Nc3 Nf6 4. Nf3) 3... Nf6 4. Nc3 { [%eval 0.16] } *",
+		"4... a6 { [%eval 0.19] } *",
+		"5. cxd5 (5. e3 e6 6. cxd5 cxd5) 5... cxd5 6. e3 e6 { [%eval 0.11] } *",
+	}
+
+	pgn := mustParsePGN("fixtures/pgns/multi_frompos_games.pgn")
 	reader := strings.NewReader(pgn)
 	scanner := NewScanner(reader)
 	validateExpand(t, scanner, expectedLastLines)


### PR DESCRIPTION
While working on replacing notnil/chess with corentings/chess in mikeb26/chesstools I ran into a handful of bugs related to .PGNs containing FEN position tags. These 3 bug fixes address the issues I found.