### PR TITLE
(bugfix) UCINotation.Decode() does not validate rank/file

### DIFF
--- a/game_test.go
+++ b/game_test.go
@@ -1228,6 +1228,25 @@ func FuzzTestPushNotationMove(f *testing.F) {
 	})
 }
 
+func TestInvalidPushNotationMove(t *testing.T) {
+	fen := "r1bqk1nr/pp1pppbp/6p1/1Bp1P3/P2n1P2/2N2N2/1PPP2PP/R1BQK2R w KQkq - 0 1"
+	bogusMv := "Kxh1"
+	opt, err := FEN(fen)
+	if err != nil {
+		t.Fatalf("FEN(fen) failed")
+	}
+	game := NewGame(opt)
+
+	err = game.PushNotationMove(bogusMv, UCINotation{}, nil)
+	if err == nil {
+		t.Errorf("PushNotationMove() (uci) succeeded in pushing bogus mv when it should have failed")
+	}
+	err = game.PushNotationMove(bogusMv, AlgebraicNotation{}, nil)
+	if err == nil {
+		t.Errorf("PushNotationMove() (alg) succeeded in pushing bogus mv when it should have failed")
+	}
+}
+
 func validateSplit(t *testing.T, origPgn string, expectedLastLines []string) {
 	reader := strings.NewReader(origPgn)
 	scanner := NewScanner(reader)

--- a/notation.go
+++ b/notation.go
@@ -135,6 +135,16 @@ func (UCINotation) Decode(pos *Position, s string) (*Move, error) {
 	if l < 4 || l > 5 {
 		return nil, fmt.Errorf("chess: invalid UCI notation length %d in %q", l, s)
 	}
+	for idx := 0; idx < 2; idx += 2 {
+		if s[idx+0] < 'a' || s[idx+0] > 'h' {
+			return nil, fmt.Errorf("chess: invalid UCI notation sq:%v file:%v",
+				idx/2, s[0])
+		}
+		if s[idx+1] < '1' || s[idx+1] > '8' {
+			return nil, fmt.Errorf("chess: invalid UCI notation sq:%v rank:%v",
+				idx/2, s[0])
+		}
+	}
 
 	// Convert directly instead of using map lookups
 	s1 := Square((s[0] - 'a') + (s[1]-'1')*8)


### PR DESCRIPTION
This commit fixes a bug in UCINotation.Decode() which would cause it to incorrectly return a non-nil error when given an input move containing a bogus rank or file.