### PR TITLE
(bugfix) Game.Clone() fails to deep copy moves

### DIFF
--- a/game.go
+++ b/game.go
@@ -714,6 +714,17 @@ func (g *Game) Clone() *Game {
 	ret := &Game{}
 	ret.copy(g)
 
+	// we have to also deep copy the moves so that modifications to the
+	// clone do not impact the parent
+	ret.rootMove = g.rootMove.Clone()
+	ret.rootMove.cloneChildren(g.rootMove.children)
+	mlen := len(ret.Moves())
+	if mlen == 0 {
+		ret.currentMove = ret.rootMove
+	} else {
+		ret.currentMove = ret.Moves()[mlen-1]
+	}
+
 	return ret
 }
 
@@ -962,7 +973,8 @@ func (g *Game) buildOneGameFromPath(path []*Move) *Game {
 		cur = child
 	}
 
-	newG := g.Clone()
+	newG := &Game{}
+	newG.copy(g)
 	newG.rootMove = rootMove
 	newG.currentMove = cur
 	newG.pos = cur.position

--- a/game_test.go
+++ b/game_test.go
@@ -800,8 +800,14 @@ func TestCloneGameState(t *testing.T) {
 	if clone.pos.String() != original.pos.String() {
 		t.Fatalf("expected position %s but got %s", original.pos.String(), clone.pos.String())
 	}
-	if clone.currentMove != original.currentMove {
+	if clone.currentMove.String() != original.currentMove.String() {
 		t.Fatalf("expected current move to be %v but got %v", original.currentMove, clone.currentMove)
+	}
+	if clone.currentMove == original.currentMove {
+		t.Errorf("clone failed to deep copy currentMove")
+	}
+	if clone.rootMove == original.rootMove {
+		t.Errorf("clone failed to deep copy rootMove")
 	}
 	if clone.outcome != original.outcome {
 		t.Fatalf("expected outcome %s but got %s", original.outcome, clone.outcome)
@@ -812,6 +818,22 @@ func TestCloneGameState(t *testing.T) {
 	if len(clone.Comments()) != len(original.Comments()) {
 		t.Fatalf("expected comments %v but got %v", original.Comments(), clone.Comments())
 	}
+
+	// make sure we can modify the clone without impact on the original
+	err := clone.PushMove("Nf6", nil)
+	if err != nil {
+		t.Fatalf("failed to push Nf6")
+	}
+	if clone.pos.String() == original.pos.String() {
+		t.Error("modifying the clone incorrectly mutates the original position")
+	}
+	if len(clone.Moves()) == len(original.Moves()) {
+		t.Errorf("modifying the clone incorrectly mutates the original moves")
+	}
+	if len(clone.Positions()) == len(original.Positions()) {
+		t.Errorf("modifying the clone incorrectly mutates the original positions")
+	}
+
 }
 
 func TestCloneGameStateWithNilComments(t *testing.T) {

--- a/move.go
+++ b/move.go
@@ -178,3 +178,16 @@ func (m *Move) Clone() *Move {
 
 	return ret
 }
+
+func (m *Move) cloneChildren(srcChildren []*Move) {
+	if srcChildren == nil || len(srcChildren) == 0 {
+		return
+	}
+
+	for _, srcMv := range srcChildren {
+		dstMv := srcMv.Clone()
+		dstMv.parent = m
+		dstMv.cloneChildren(srcMv.children)
+		m.children = append(m.children, dstMv)
+	}
+}


### PR DESCRIPTION
Currently if a game is cloned and the child is subsequently mutated, e.g.

child := parent.Clone()
child.PushMove("Nf6", nil)

the parent is incorrectly mutated. This commit fixes the issue by deep copying the moves in Game.Clone(). Additionally we augment the tests to catch this situation.