### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       go-version: '^1.22'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/CorentinGS/chess/security/code-scanning/1](https://github.com/CorentinGS/chess/security/code-scanning/1)

The best fix is to add an explicit `permissions` block to the `setup` job at the same level as `runs-on` in the `.github/workflows/ci.yaml` file. Since the `setup` job only checks out code and sets up Go, both of which require only read access to repository contents, the minimal permission required is `contents: read`. No additional imports, method definitions, or configuration are necessary. This change is limited to the YAML workflow file; only the `setup` job needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
