### PR TITLE
Fix finished games parsed from PGN not having Checkmate method when appropriate

### DIFF
--- a/pgn.go
+++ b/pgn.go
@@ -727,6 +727,7 @@ func (p *Parser) addMove(move *Move) {
 	// Update position
 	if newPos := p.game.pos.Update(move); newPos != nil {
 		p.game.pos = newPos
+		p.game.evaluatePositionStatus()
 	}
 
 	// Cache position before the move


### PR DESCRIPTION
Fixes issue #76. Adds a status update to the logic that parses moves from PGN, so that a finished game correctly has checkmate as its method after parsing. 