### PR TITLE
fix: comply with FIDE 9.2.2 in samePosition en passant check

### DIFF
--- a/position.go
+++ b/position.go
@@ -441,10 +441,58 @@ func (pos *Position) updateEnPassantSquare(m *Move) Square {
 	return NoSquare
 }
 
-// samePosition returns true if the two positions are the same.
+// samePosition returns true if the two positions are the same
+// according to FIDE Article 9.2.2. The en passant square is only
+// considered if an en passant capture is actually possible (i.e.,
+// there is an opponent pawn on an adjacent file that could capture).
 func (pos *Position) samePosition(pos2 *Position) bool {
 	return pos.board.String() == pos2.board.String() &&
 		pos.turn == pos2.turn &&
 		pos.castleRights.String() == pos2.castleRights.String() &&
-		pos.enPassantSquare == pos2.enPassantSquare
+		pos.relevantEnPassantSquare() == pos2.relevantEnPassantSquare()
+}
+
+// relevantEnPassantSquare returns the en passant square only if
+// an en passant capture is actually possible. Per FIDE rules,
+// the en passant square is only relevant if there is an opponent
+// pawn that can make the capture.
+func (pos *Position) relevantEnPassantSquare() Square {
+	if pos.enPassantSquare == NoSquare {
+		return NoSquare
+	}
+	// The en passant square is the square the capturing pawn moves TO.
+	// The capturing pawn must be on an adjacent file, on the same rank
+	// as the pawn that just advanced two squares.
+	//
+	// If the en passant square is on rank 3, the capturing pawn (black)
+	// must be on rank 4. If on rank 6, the capturing pawn (white)
+	// must be on rank 5.
+	epFile := pos.enPassantSquare.File()
+	epRank := pos.enPassantSquare.Rank()
+
+	var captureRank Rank
+	var capturingPawn Piece
+	if epRank == Rank3 {
+		captureRank = Rank4
+		capturingPawn = BlackPawn
+	} else {
+		captureRank = Rank5
+		capturingPawn = WhitePawn
+	}
+
+	// Check adjacent files for a pawn that could capture
+	if epFile > FileA {
+		sq := NewSquare(epFile-1, captureRank)
+		if pos.board.Piece(sq) == capturingPawn {
+			return pos.enPassantSquare
+		}
+	}
+	if epFile < FileH {
+		sq := NewSquare(epFile+1, captureRank)
+		if pos.board.Piece(sq) == capturingPawn {
+			return pos.enPassantSquare
+		}
+	}
+
+	return NoSquare
 }

--- a/position.go
+++ b/position.go
@@ -442,9 +442,10 @@ func (pos *Position) updateEnPassantSquare(m *Move) Square {
 }
 
 // samePosition returns true if the two positions are the same
-// according to FIDE Article 9.2.2. The en passant square is only
+// according to FIDE Article 9.2.3. The en passant square is only
 // considered if an en passant capture is actually possible (i.e.,
-// there is an opponent pawn on an adjacent file that could capture).
+// there is an opponent pawn on an adjacent file that could capture)
+// per FIDE Article 9.2.3.1.
 func (pos *Position) samePosition(pos2 *Position) bool {
 	return pos.board.String() == pos2.board.String() &&
 		pos.turn == pos2.turn &&

--- a/position_test.go
+++ b/position_test.go
@@ -85,3 +85,64 @@ func TestPositionPly(t *testing.T) {
 		}
 	}
 }
+
+func TestSamePositionEnPassantFIDECompliance(t *testing.T) {
+	// FIDE Article 9.2.2: positions are the same only if "the possible
+	// moves of all the pieces are the same". An en passant square should
+	// only matter when an en passant capture is actually possible.
+
+	// Position with en passant square set but no pawn can capture:
+	// White pawn on e4 (just pushed e2-e4), en passant square e3,
+	// but no black pawn on d4 or f4 to capture.
+	posWithIrrelevantEP, err := decodeFEN("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Same board position but without en passant square set.
+	posWithoutEP, err := decodeFEN("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// These should be considered the same position because no en passant
+	// capture is possible (no black pawn on d4 or f4).
+	if !posWithIrrelevantEP.samePosition(posWithoutEP) {
+		t.Error("positions with irrelevant en passant square should be considered the same")
+	}
+
+	// Position where en passant IS possible:
+	// White pawn on e4, black pawn on d4. En passant square e3.
+	// Black pawn on d4 can capture en passant on e3.
+	posWithRelevantEP, err := decodeFEN("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Same board but without en passant square.
+	posWithRelevantNoEP, err := decodeFEN("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// These should NOT be considered the same because the en passant
+	// capture is actually possible.
+	if posWithRelevantEP.samePosition(posWithRelevantNoEP) {
+		t.Error("positions with relevant en passant square should be considered different")
+	}
+
+	// Test with black pawn on f4 (right side of e4 pawn).
+	posWithRelevantEPRight, err := decodeFEN("rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	posWithRelevantEPRightNoEP, err := decodeFEN("rnbqkbnr/pppp1ppp/8/8/4Pp2/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if posWithRelevantEPRight.samePosition(posWithRelevantEPRightNoEP) {
+		t.Error("positions with relevant en passant square (right adjacent pawn) should be considered different")
+	}
+}

--- a/position_test.go
+++ b/position_test.go
@@ -87,9 +87,10 @@ func TestPositionPly(t *testing.T) {
 }
 
 func TestSamePositionEnPassantFIDECompliance(t *testing.T) {
-	// FIDE Article 9.2.2: positions are the same only if "the possible
-	// moves of all the pieces are the same". An en passant square should
-	// only matter when an en passant capture is actually possible.
+	// FIDE Article 9.2.3: positions are the same only if "the possible
+	// moves of all the pieces are the same". Per Article 9.2.3.1, an en
+	// passant square should only matter when a pawn could have been
+	// captured en passant (i.e., the capture is actually possible).
 
 	// Position with en passant square set but no pawn can capture:
 	// White pawn on e4 (just pushed e2-e4), en passant square e3,


### PR DESCRIPTION
### Overview
Fix `samePosition` to comply with FIDE Article 9.2.3 for threefold repetition detection.

### Problem
The current `samePosition` method compares en passant squares directly:
```go
pos.enPassantSquare == pos2.enPassantSquare
```

Per **FIDE Article 9.2.3.1**, positions are only different if "a pawn **could have been** captured en passant" — meaning an opponent pawn must actually be on an adjacent file to make the capture. The current implementation treats positions as different even when the en passant square is set but no pawn can capture there.

**Example:** After `1.f4 Nf6 2.Nf3 Ng8 3.Ng1 Nf6 4.Nf3 Ng8 5.Ng1`, the position after move 1 (with en passant square f3 but no black pawn on e4/g4) is the same as positions after moves 5 and 9. This should be detected as threefold repetition, but currently isn't.

### Fix
Added `relevantEnPassantSquare()` which returns `NoSquare` when no opponent pawn on an adjacent file can actually make the en passant capture. `samePosition` now compares `relevantEnPassantSquare()` instead of raw `enPassantSquare`.

### Tests
Added `TestSamePositionEnPassantFIDECompliance` with three test cases:
- Irrelevant en passant (no adjacent pawn) — positions should be considered the same
- Relevant en passant with left-adjacent pawn — positions should differ
- Relevant en passant with right-adjacent pawn — positions should differ

All existing tests pass.